### PR TITLE
ttf file's name mismatch fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         <div class="col-md-8">
           <div class="col-sm-4 col-md-4 col-lg-4"><div class="font-link"><a href="assets/fonts/SourceSansPro-Light.ttf"><p class="font-lead">Source Sans Pro Light</p><p class="font-example SourceSansPro-Light">AaBbCc</p></a></div></div>
           <div class="col-sm-4 col-md-4 col-lg-4"><div class="font-link"><a href="assets/fonts/SourceSansPro-Regular.ttf"><p class="font-lead">Source Sans Pro Regular</p><p class="font-example SourceSansPro-Regular">AaBbCc</p></a></div></div>
-          <div class="col-sm-4 col-md-4 col-lg-4"><div class="font-link"><a href="assets/fonts/SourceSansPro-SemiBold.ttf"><p class="font-lead">Source Sans Pro DemiBold</p><p class="font-example SourceSansPro-SemiBold">AaBbCc</p></a></div></div>
+          <div class="col-sm-4 col-md-4 col-lg-4"><div class="font-link"><a href="assets/fonts/SourceSansPro-Semibold.ttf"><p class="font-lead">Source Sans Pro DemiBold</p><p class="font-example SourceSansPro-SemiBold">AaBbCc</p></a></div></div>
           <div class="col-sm-4 col-md-4 col-lg-4"><div class="font-link"><a href="assets/fonts/OpenSans-CondLight.ttf"><p class="font-lead">Open Sans Condensed Light</p><p class="font-example OpenSans-CondLight">AaBbCc</p></a></div></div>
           <div class="col-sm-4 col-md-4 col-lg-4"><div class="font-link"><a href="assets/fonts/OpenSans-CondBold.ttf"><p class="font-lead">Open Sans Condensed Bold</p><p class="font-example OpenSans-CondBold">AaBbCc</p></a></div></div>
           <div class="col-sm-4 col-md-4 col-lg-4"><div class="font-link"><a href="assets/fonts/OpenSans-Regular.ttf"><p class="font-lead">Open Sans Regular</p><p class="font-example OpenSans-Regular">AaBbCc</p></a></div></div>


### PR DESCRIPTION
Font -- Source Sans Pro DemiBold was not downloadable on the [Branding Guidelines page](https://opensuse.github.io/branding-guidelines/ ) because of a typo. Now, fixed.